### PR TITLE
:pencil2: Fix typo in styling option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ tv [FLAGS] [OPTIONS] [PATH]
 ```
 -a, --align <left | center | right | none>                  Table alignment [default: none]
 -s, --sort <SORT_KEY>                                       Options for sorting by key
-    --style <ascii | sharp | rounded | markdown | plane>    Table style [default: ascii]
+    --style <ascii | sharp | rounded | markdown | plain>    Table style [default: ascii]
 ```
 
 ### ARGS

--- a/src/application.rs
+++ b/src/application.rs
@@ -43,7 +43,7 @@ impl<'a, 'b> Application<'a, 'b> {
             .arg(
                 Arg::with_name("style")
                     .long("style")
-                    .value_name("ascii | sharp | rounded | markdown | plane")
+                    .value_name("ascii | sharp | rounded | markdown | plane | plain")
                     .help("Table style")
                     .takes_value(true)
                     .default_value("ascii"),

--- a/src/table/style.rs
+++ b/src/table/style.rs
@@ -1,6 +1,6 @@
 #[derive(Debug, Clone, Copy)]
 pub enum Style {
-    Plane,
+    Plain,
     Ascii,
     Sharp,
     Rounded,
@@ -10,7 +10,8 @@ pub enum Style {
 impl Style {
     pub fn new(s: String) -> Self {
         match s.to_lowercase().as_str() {
-            "plane" => Self::Plane,
+            "plane" => Self::Plain, // deprecated
+            "plain" => Self::Plain,
             "ascii" => Self::Ascii,
             "sharp" => Self::Sharp,
             "rounded" => Self::Rounded,
@@ -38,7 +39,7 @@ pub struct Frame {
 impl From<Style> for Frame {
     fn from(style: Style) -> Self {
         match style {
-            Style::Plane => Self {
+            Style::Plain => Self {
                 has_cover: false,
                 border: "".into(),
                 separator: "\t".into(),


### PR DESCRIPTION
"plain" is correct, instead of "plane".
Keeping "plane" for backward compatibility.