### PR TITLE
:pencil2: Fix typo on .commit_template

### DIFF
--- a/.commit_template
+++ b/.commit_template
@@ -2,7 +2,7 @@
 
 # ==================== Emojis ====================
 # ✨  :sparkles: New Feature
-# 🐛  :bug: Bagfix
+# 🐛  :bug: Bugfix
 # ♻️   :recycle: Refactoring
 # 🐎  :horse: Performance
 # 📚  :books: Documentation


### PR DESCRIPTION
Hi, @uzimaru0000. Thanks for the great tool.
I found a very tiny typo on `.commit_template`. I opened PR.
